### PR TITLE
更正ScollView中isShowBar属性的几个bug

### DIFF
--- a/src/android/doExt_Do_ScrollView/src/extimplement/Do_ScrollView_View.java
+++ b/src/android/doExt_Do_ScrollView/src/extimplement/Do_ScrollView_View.java
@@ -11,6 +11,7 @@ import android.widget.HorizontalScrollView;
 import android.widget.LinearLayout;
 import android.widget.ScrollView;
 import core.DoServiceContainer;
+import core.helper.DoTextHelper;
 import core.helper.DoUIModuleHelper;
 import core.helper.DoUIModuleHelper.LayoutParamsType;
 import core.helper.jsonparse.DoJsonNode;
@@ -21,8 +22,8 @@ import core.object.DoInvokeResult;
 import core.object.DoSourceFile;
 import core.object.DoUIContainer;
 import core.object.DoUIModule;
-import extdefine.Do_ScrollView_IMethod;
-import extdefine.Do_ScrollView_MAbstract;
+import extdefine.do_ScrollView_IMethod;
+import extdefine.do_ScrollView_MAbstract;
 
 /**
  * 自定义扩展UIView组件实现类，此类必须继承相应VIEW类，并实现DoIUIModuleView,Do_ScrollView_IMethod接口；
@@ -31,7 +32,7 @@ import extdefine.Do_ScrollView_MAbstract;
  * 参数解释：@_messageName字符串事件名称，@jsonResult传递事件参数对象；
  * 获取DoInvokeResult对象方式new DoInvokeResult(this.model.getUniqueKey());
  */
-public class Do_ScrollView_View extends LinearLayout implements DoIUIModuleView,Do_ScrollView_IMethod{
+public class do_ScrollView_View extends LinearLayout implements DoIUIModuleView,do_ScrollView_IMethod{
 
 	private static final int PULL_TO_REFRESH = 0; // 下拉刷新
 	private static final int RELEASE_TO_REFRESH = 1; // 松开后刷新
@@ -40,7 +41,7 @@ public class Do_ScrollView_View extends LinearLayout implements DoIUIModuleView,
 	/**
 	 * 每个UIview都会引用一个具体的model实例；
 	 */
-	private Do_ScrollView_MAbstract model;
+	private do_ScrollView_MAbstract model;
 	private String defaultDirection = "vertical";
 	private DoIScrollView doIScrollView;
 	private View childView;
@@ -53,7 +54,7 @@ public class Do_ScrollView_View extends LinearLayout implements DoIUIModuleView,
 	private String headerViewAddress; // headerview 的地址
 	
 
-	public Do_ScrollView_View(Context context) {
+	public do_ScrollView_View(Context context) {
 		super(context);
 		this.setOrientation(VERTICAL);
 	}
@@ -63,7 +64,7 @@ public class Do_ScrollView_View extends LinearLayout implements DoIUIModuleView,
 	 */
 	@Override
 	public void loadView(DoUIModule _doUIModule) throws Exception {
-		this.model = (Do_ScrollView_MAbstract)_doUIModule;
+		this.model = (do_ScrollView_MAbstract)_doUIModule;
 		int childSize = model.getChildUIModules().size();
 		if (childSize == 0) {
 			return;
@@ -124,8 +125,8 @@ public class Do_ScrollView_View extends LinearLayout implements DoIUIModuleView,
 	public void onPropertiesChanged(Map<String, String> _changedValues) {
 		DoUIModuleHelper.handleBasicViewProperChanged(this.model, _changedValues);
 		if (_changedValues.containsKey("isShowbar")) {
-			boolean verticalScrollBarEnabled = Boolean.parseBoolean(_changedValues.get("isShowbar"));
-			doIScrollView.isShowbar(verticalScrollBarEnabled);
+			boolean scrollBarEnabled = DoTextHelper.strToBool(_changedValues.get("isShowbar"), false);
+			doIScrollView.isShowbar(scrollBarEnabled);
 		}
 	}
 	
@@ -431,6 +432,7 @@ public class Do_ScrollView_View extends LinearLayout implements DoIUIModuleView,
 			super(context);
 			this.setFillViewport(true);
 			this.setBackgroundColor(Color.TRANSPARENT);
+			this.setHorizontalScrollBarEnabled(false);
 		}
 
 		@Override
@@ -454,8 +456,8 @@ public class Do_ScrollView_View extends LinearLayout implements DoIUIModuleView,
 		}
 
 		@Override
-		public void isShowbar(boolean verticalScrollBarEnabled) {
-			this.setVerticalScrollBarEnabled(verticalScrollBarEnabled);
+		public void isShowbar(boolean horizontalScrollBarEnabled) {
+			this.setHorizontalScrollBarEnabled(horizontalScrollBarEnabled);
 		}
 
 		@Override
@@ -472,6 +474,7 @@ public class Do_ScrollView_View extends LinearLayout implements DoIUIModuleView,
 			super(context);
 			this.setFillViewport(true);
 			this.setBackgroundColor(Color.TRANSPARENT);
+			this.setVerticalScrollBarEnabled(false);
 		}
 
 		@Override

--- a/src/android/doExt_Do_ScrollView/src/extimplement/do_ScrollView_Model.java
+++ b/src/android/doExt_Do_ScrollView/src/extimplement/do_ScrollView_Model.java
@@ -1,0 +1,15 @@
+package extimplement;
+
+import extdefine.do_ScrollView_MAbstract;
+
+/**
+ * 自定义扩展组件Model实现，继承Do_ScrollView_MAbstract抽象类；
+ *
+ */
+public class do_ScrollView_Model extends do_ScrollView_MAbstract {
+
+	public do_ScrollView_Model() throws Exception {
+		super();
+	}
+	
+}


### PR DESCRIPTION
1.HScollView的isShowbar方法原来设置的是VerticalScollBarEnabled属性，更正为HorizontalScrollBarEnabled属性
2.相应的在propertyChanged函数里将变量名verticalScrollBarEnabled改成scrollBarEnabled
3.在两个内部类HScrollView和VScrollView的构造函数里添加this.setHorizontalScrollBarEnabled(false)和this.setVerticalScrollBarEnabled(false);语句，从而匹配设计文档的初始值设定
